### PR TITLE
Title: feat(UX): Improve Household & Chore Creation Flows

### DIFF
--- a/src/components/AddExpenseModal.tsx
+++ b/src/components/AddExpenseModal.tsx
@@ -3,11 +3,11 @@
 
 import React, { useState } from 'react';
 import { Loader2 } from 'lucide-react';
-import * as api from '@/lib/api';
+import { createExpenseWithCustomSplits } from '@/lib/api/expenses';
 import { toast } from 'react-hot-toast';
-import type { HouseholdMember } from '@/lib/api';
+import type { HouseholdMember } from '@/lib/types/types';
 import { useExpenseSplits } from '@/hooks/useExpenseSplits';
-import { ExpenseSplitter } from './ExpenseSplitter';
+import { ExpenseSplitter } from '@/components/ExpenseSplitter';
 import { Button } from '@/components/ui/Button';
 
 interface AddExpenseModalProps {
@@ -36,7 +36,7 @@ export const AddExpenseModal: React.FC<AddExpenseModalProps> = ({ householdId, m
     
     setSubmitting(true);
     try {
-      await api.createExpenseWithCustomSplits(householdId, description, amount, finalSplits);
+      await createExpenseWithCustomSplits(householdId, description, amount, finalSplits);
       toast.success('Expense added!');
       onExpenseAdded();
       onClose();

--- a/src/components/AddTaskModal.tsx
+++ b/src/components/AddTaskModal.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import * as api from '@/lib/api';
 import { toast } from 'react-hot-toast';
-import type { HouseholdMember } from '@/lib/api';
+import type { HouseholdMember } from '@/lib/types/types';
 import { Button } from '@/components/ui/Button';
 
 interface AddTaskModalProps {

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -2,7 +2,7 @@
 import React, { createContext, useContext, useEffect, useState, useMemo, useCallback } from 'react';
 import { supabase } from '@/lib/supabase';
 import { User } from '@supabase/supabase-js';
-import type { Profile } from '@/lib/api';
+import type { Profile } from '@/lib/types/types';
 import * as api from '@/lib/api';
 
 interface AuthContextType {

--- a/src/components/ChoreDashboard.tsx
+++ b/src/components/ChoreDashboard.tsx
@@ -2,15 +2,15 @@
 "use client";
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { CheckCircle, Circle, PlusCircle, RefreshCw, AlertTriangle, Loader2, ClipboardList, Edit, ToggleLeft, ToggleRight } from 'lucide-react';
-import { 
-  addCustomChoreToHousehold, 
-  assignChoresForCurrentCycle, 
-  checkAndTriggerChoreRotation, 
-  getChoreRotationUIData, 
-  getHouseholdChores, 
-  markChoreAssignmentComplete, 
-  toggleChoreActive, 
-  updateHouseholdChore 
+import {
+  addCustomChoreToHousehold,
+  assignChoresForCurrentCycle,
+  checkAndTriggerChoreRotation,
+  getChoreRotationUIData,
+  getHouseholdChores,
+  markChoreAssignmentComplete,
+  toggleChoreActive,
+  updateHouseholdChore
 } from '@/lib/api/chores';
 import type { ChoreAssignment, Household, HouseholdMember, HouseholdChore } from '@/lib/types/types';
 import { useAuth } from './AuthProvider';
@@ -30,9 +30,8 @@ const getInitials = (name?: string | null) => {
   return name.substring(0, 2);
 };
 
-// (ChoreCard component remains the same)
-const ChoreCard: React.FC<{ 
-  assignment: ChoreAssignment; 
+const ChoreCard: React.FC<{
+  assignment: ChoreAssignment;
   currentUserId: string | undefined;
   onMarkComplete: (assignmentId: string) => void;
   isLoadingCompletion: boolean;
@@ -96,7 +95,6 @@ const ChoreCard: React.FC<{
   );
 };
 
-// (AddChoreModal component remains the same)
 const AddChoreModal: React.FC<{
     householdId: string;
     onChoreAdded: () => void;
@@ -156,7 +154,6 @@ const AddChoreModal: React.FC<{
     );
 };
 
-// ** NEW COMPONENT **
 const EditChoreModal: React.FC<{
     chore: HouseholdChore;
     onChoreUpdated: () => void;
@@ -214,14 +211,14 @@ const EditChoreModal: React.FC<{
 };
 
 
-// ** NEW COMPONENT **
 const ManageChoresModal: React.FC<{
     chores: HouseholdChore[];
     isAdmin: boolean;
     onClose: () => void;
+    onAddChore: () => void;
     onEdit: (chore: HouseholdChore) => void;
     onToggleActive: (choreId: string, isActive: boolean) => void;
-}> = ({ chores, isAdmin, onClose, onEdit, onToggleActive }) => {
+}> = ({ chores, isAdmin, onClose, onAddChore, onEdit, onToggleActive }) => {
     return (
          <div className="fixed inset-0 bg-black bg-opacity-50 overflow-y-auto h-full w-full z-50 flex items-center justify-center p-4">
             <div className="bg-background p-6 rounded-lg shadow-xl w-full max-w-lg">
@@ -246,7 +243,11 @@ const ManageChoresModal: React.FC<{
                         </div>
                     ))}
                 </div>
-                 <div className="mt-6 flex justify-end">
+                 <div className="mt-6 flex justify-between items-center">
+                    <Button onClick={onAddChore} variant="outline">
+                        <PlusCircle className="h-4 w-4 mr-2"/>
+                        Add Chore
+                    </Button>
                     <Button onClick={onClose}>Done</Button>
                 </div>
             </div>
@@ -342,8 +343,13 @@ export const ChoreDashboard: React.FC<ChoreDashboardProps> = ({ householdId }) =
 
   const handleOpenEditChore = (chore: HouseholdChore) => {
       setChoreToEdit(chore);
-      setShowManageChoresModal(false); // Close manage modal before opening edit
+      setShowManageChoresModal(false);
   }
+
+  const handleOpenAddChoreFromManager = () => {
+    setShowManageChoresModal(false);
+    setShowAddChoreModal(true);
+  };
 
   const handleToggleChoreActive = async (choreId: string, newStatus: boolean) => {
     try {
@@ -475,6 +481,7 @@ export const ChoreDashboard: React.FC<ChoreDashboardProps> = ({ householdId }) =
             chores={allChores}
             isAdmin={isAdmin}
             onClose={() => setShowManageChoresModal(false)}
+            onAddChore={handleOpenAddChoreFromManager}
             onEdit={handleOpenEditChore}
             onToggleActive={handleToggleChoreActive}
         />

--- a/src/components/HouseholdChat.tsx
+++ b/src/components/HouseholdChat.tsx
@@ -5,7 +5,7 @@ import { Send, Loader2 } from 'lucide-react';
 import { useAuth } from './AuthProvider';
 import * as api from '@/lib/api';
 import { subscriptionManager } from '@/lib/subscriptionManager';
-import type { Message } from '@/lib/api';
+import type { Message } from '@/lib/types/types';
 import { Button } from '@/components/ui/Button';
 import { toast } from 'react-hot-toast';
 

--- a/src/components/HouseholdSetupForm.tsx
+++ b/src/components/HouseholdSetupForm.tsx
@@ -11,6 +11,7 @@ import { Loader2 } from 'lucide-react';
 
 interface HouseholdSetupFormProps {
   onHouseholdCreated: (householdId: string) => void;
+  onCancel: () => void;
 }
 
 interface ChoreOptionType {
@@ -18,7 +19,7 @@ interface ChoreOptionType {
   label: string;
 }
 
-export const HouseholdSetupForm: React.FC<HouseholdSetupFormProps> = ({ onHouseholdCreated }) => {
+export const HouseholdSetupForm: React.FC<HouseholdSetupFormProps> = ({ onHouseholdCreated, onCancel }) => {
   const { user } = useAuth();
   const [householdName, setHouseholdName] = useState('');
   const [memberCount, setMemberCount] = useState(2);
@@ -86,7 +87,6 @@ export const HouseholdSetupForm: React.FC<HouseholdSetupFormProps> = ({ onHouseh
     coreChores.includes(option.value)
   );
 
-  // A generic input style to match the design system
   const inputStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm";
 
   return (
@@ -174,19 +174,25 @@ export const HouseholdSetupForm: React.FC<HouseholdSetupFormProps> = ({ onHouseh
           </select>
         </div>
 
-        <Button
-          type="submit"
-          disabled={isLoading}
-          className="w-full"
-        >
-          {isLoading ? <Loader2 className="animate-spin" /> : 'Create Household'}
-        </Button>
+        <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-3 mt-6">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onCancel}
+              disabled={isLoading}
+              className="w-full sm:w-auto mt-2 sm:mt-0"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={isLoading}
+              className="w-full sm:w-auto"
+            >
+              {isLoading ? <Loader2 className="animate-spin" /> : 'Create Household'}
+            </Button>
+        </div>
       </form>
     </div>
   );
 };
-// src/components/HouseholdSetupForm.tsx
-// This component allows users to set up their household with a name, member count, core chores, chore frequency, and chore framework.
-// It uses a form to collect the necessary information and calls the `createHousehold` API function to create the household.
-// It also handles validation and displays any errors that occur during the creation process.
-// src/components/HouseholdSetupForm.tsx

--- a/src/hooks/useExpenseSplits.ts
+++ b/src/hooks/useExpenseSplits.ts
@@ -1,6 +1,6 @@
 // src/hooks/useExpenseSplits.ts
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import type { HouseholdMember } from '@/lib/api';
+import type { HouseholdMember } from '@/lib/types/types';
 
 export type SplitType = 'equal' | 'custom' | 'percentage';
 


### PR DESCRIPTION
Description

This PR introduces two significant user experience improvements to make navigation more intuitive and chore management more efficient.

Context-Aware Back Navigation: This fixes a confusing navigation flow where users, especially those already part of a household, would be sent back to the initial onboarding screen after cancelling a "Create" or "Join" household action. The navigation logic is now context-aware and will return the user to their dashboard if they initiated the action from there.

Streamlined Chore Creation: Previously, an administrator had to exit the "Manage Chores" modal to add a new chore. This change adds an "Add Chore" button directly within the modal, removing unnecessary clicks and making the workflow more seamless.

Changes

src/components/RoomiesApp.tsx

Added a new state (userHasHouseholds) to the main App component to track if a user is part of at least one household.
The "Back" and "Cancel" actions for the householdSetup and joinWithCode flows now use this state to dynamically navigate to the correct previous screen (either the dashboard or onboardingChoice).
Wrapped the creation/join components in the Layout component to provide a consistent header and back arrow.
src/components/HouseholdSetupForm.tsx

Added an onCancel prop and a corresponding "Cancel" button to the form, allowing it to be controlled by the parent component's navigation logic.
src/components/ChoreDashboard.tsx

Added an "Add Chore" button to the footer of the ManageChoresModal.
This button triggers a new handler that closes the management modal and immediately opens the "Add New Chore" modal.