### PR TITLE
feat(ui): Introduce and integrate shadcn/ui Input component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,20 @@
       "name": "roomies_app",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-collapsible": "^1.1.11",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.49.8",
         "@tailwindcss/container-queries": "^0.1.1",
         "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "lucide-react": "^0.511.0",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
-        "react-select": "^5.10.1"
+        "react-select": "^5.10.1",
+        "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1237,6 +1240,207 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.11.tgz",
+      "integrity": "sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1427,7 +1631,7 @@
       "version": "19.1.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
       "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -6422,6 +6626,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -9,17 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-collapsible": "^1.1.11",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.8",
     "@tailwindcss/container-queries": "^0.1.1",
     "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "lucide-react": "^0.511.0",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
-    "react-select": "^5.10.1"
+    "react-select": "^5.10.1",
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/components/AddExpenseModal.tsx
+++ b/src/components/AddExpenseModal.tsx
@@ -9,6 +9,7 @@ import type { HouseholdMember } from '@/lib/types/types';
 import { useExpenseSplits } from '@/hooks/useExpenseSplits';
 import { ExpenseSplitter } from '@/components/ExpenseSplitter';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
 
 interface AddExpenseModalProps {
   householdId: string;
@@ -48,8 +49,6 @@ export const AddExpenseModal: React.FC<AddExpenseModalProps> = ({ householdId, m
     }
   };
 
-  const inputStyles = "w-full border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm";
-
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 overflow-y-auto">
       <div className="bg-background rounded-lg p-6 max-w-2xl w-full my-8">
@@ -57,9 +56,9 @@ export const AddExpenseModal: React.FC<AddExpenseModalProps> = ({ householdId, m
         <div className="space-y-4">
           <div>
             <label className="block text-sm font-medium text-foreground">Description</label>
-            <input 
+            <Input 
               type="text" 
-              className={`mt-1 px-3 py-2 ${inputStyles}`} 
+              className="mt-1"
               value={description} 
               onChange={(e) => setDescription(e.target.value)} 
               placeholder="What's this expense for?" 
@@ -71,10 +70,10 @@ export const AddExpenseModal: React.FC<AddExpenseModalProps> = ({ householdId, m
               <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                 <span className="text-secondary-foreground sm:text-sm">$</span>
               </div>
-              <input 
+              <Input 
                 type="number" 
                 step="0.01" 
-                className={`pl-7 pr-3 py-2 ${inputStyles}`} 
+                className="pl-7"
                 value={amount || ''} 
                 onChange={(e) => setAmount(parseFloat(e.target.value))} 
                 placeholder="0.00" 

--- a/src/components/AddRecurringExpenseModal.tsx
+++ b/src/components/AddRecurringExpenseModal.tsx
@@ -6,6 +6,7 @@ import { Loader2 } from 'lucide-react';
 import * as api from '@/lib/api';
 import { toast } from 'react-hot-toast';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
 
 interface AddRecurringExpenseModalProps {
   householdId: string;
@@ -45,8 +46,6 @@ export const AddRecurringExpenseModal: React.FC<AddRecurringExpenseModalProps> =
         setFrequency(e.target.value as FrequencyType);
     };
 
-    const inputStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm";
-
     return (
       <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
         <div className="bg-background rounded-lg p-6 max-w-md w-full">
@@ -54,15 +53,15 @@ export const AddRecurringExpenseModal: React.FC<AddRecurringExpenseModalProps> =
           <div className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-foreground">Description</label>
-              <input type="text" placeholder="e.g., Rent" className={inputStyles} value={description} onChange={(e) => setDescription(e.target.value)} />
+              <Input type="text" placeholder="e.g., Rent" className="mt-1" value={description} onChange={(e) => setDescription(e.target.value)} />
             </div>
             <div>
               <label className="block text-sm font-medium text-foreground">Amount</label>
-              <input type="number" step="0.01" className={inputStyles} value={amount} onChange={(e) => setAmount(e.target.value)} />
+              <Input type="number" step="0.01" className="mt-1" value={amount} onChange={(e) => setAmount(e.target.value)} />
             </div>
             <div>
               <label className="block text-sm font-medium text-foreground">Frequency</label>
-              <select className={inputStyles} value={frequency} onChange={handleFrequencyChange}>
+              <select className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50" value={frequency} onChange={handleFrequencyChange}>
                 <option value="weekly">Weekly</option>
                 <option value="biweekly">Bi-weekly</option>
                 <option value="monthly">Monthly</option>
@@ -73,7 +72,7 @@ export const AddRecurringExpenseModal: React.FC<AddRecurringExpenseModalProps> =
             {(frequency === 'monthly' || frequency === 'quarterly' || frequency === 'yearly') && (
               <div>
                 <label className="block text-sm font-medium text-foreground">Day of Month (1-31)</label>
-                <input type="number" min="1" max="31" className={inputStyles} value={dayOfMonth} onChange={(e) => setDayOfMonth(e.target.value)} />
+                <Input type="number" min="1" max="31" className="mt-1" value={dayOfMonth} onChange={(e) => setDayOfMonth(e.target.value)} />
               </div>
             )}
           </div>

--- a/src/components/AddTaskModal.tsx
+++ b/src/components/AddTaskModal.tsx
@@ -7,6 +7,7 @@ import * as api from '@/lib/api';
 import { toast } from 'react-hot-toast';
 import type { HouseholdMember } from '@/lib/types/types';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
 
 interface AddTaskModalProps {
   householdId: string;
@@ -37,8 +38,6 @@ export const AddTaskModal: React.FC<AddTaskModalProps> = ({ householdId, members
       }
     };
 
-    const inputStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm";
-
     return (
       <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
         <div className="bg-background rounded-lg p-6 max-w-md w-full">
@@ -46,11 +45,11 @@ export const AddTaskModal: React.FC<AddTaskModalProps> = ({ householdId, members
           <div className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-foreground">Task</label>
-              <input type="text" className={inputStyles} value={title} onChange={(e) => setTitle(e.target.value)} />
+              <Input type="text" className="mt-1" value={title} onChange={(e) => setTitle(e.target.value)} />
             </div>
             <div>
               <label className="block text-sm font-medium text-foreground">Assign to (optional)</label>
-              <select className={inputStyles} value={assignedTo} onChange={(e) => setAssignedTo(e.target.value)}>
+              <select className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50" value={assignedTo} onChange={(e) => setAssignedTo(e.target.value)}>
                 <option value="">Unassigned</option>
                 {members.map(member => (
                   <option key={member.user_id} value={member.user_id}>{member.profiles?.name}</option>

--- a/src/components/ChoreDashboard.tsx
+++ b/src/components/ChoreDashboard.tsx
@@ -16,6 +16,7 @@ import type { ChoreAssignment, Household, HouseholdMember, HouseholdChore } from
 import { useAuth } from './AuthProvider';
 import { toast } from 'react-hot-toast';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
 //yes, this is a client component
 interface ChoreDashboardProps {
   householdId: string;
@@ -123,7 +124,7 @@ const AddChoreModal: React.FC<{
         }
     };
 
-    const inputStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm";
+    const textareaStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm resize-none";
 
     return (
         <div className="fixed inset-0 bg-black bg-opacity-50 overflow-y-auto h-full w-full z-50 flex items-center justify-center p-4">
@@ -132,13 +133,13 @@ const AddChoreModal: React.FC<{
                 <div className="space-y-4">
                     <div>
                         <label htmlFor="choreName" className="block text-sm font-medium text-foreground">Chore Name <span className="text-destructive">*</span></label>
-                        <input type="text" id="choreName" value={choreName} onChange={(e) => setChoreName(e.target.value)}
-                               className={inputStyles} placeholder="e.g., Clean the kitchen"/>
+                        <Input type="text" id="choreName" value={choreName} onChange={(e) => setChoreName(e.target.value)}
+                               className="mt-1" placeholder="e.g., Clean the kitchen"/>
                     </div>
                     <div>
                         <label htmlFor="choreDescription" className="block text-sm font-medium text-foreground">Description (Optional)</label>
                         <textarea id="choreDescription" value={choreDescription} onChange={(e) => setChoreDescription(e.target.value)} rows={3}
-                                  className={inputStyles} placeholder="e.g., Wipe counters, clean sink, sweep floor"/>
+                                  className={textareaStyles} placeholder="e.g., Wipe counters, clean sink, sweep floor"/>
                     </div>
                 </div>
                 <div className="mt-6 flex justify-end space-x-3">
@@ -183,7 +184,7 @@ const EditChoreModal: React.FC<{
         }
     };
     
-    const inputStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm";
+    const textareaStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm resize-none";
 
     return (
         <div className="fixed inset-0 bg-black bg-opacity-50 overflow-y-auto h-full w-full z-50 flex items-center justify-center p-4">
@@ -192,11 +193,11 @@ const EditChoreModal: React.FC<{
                 <div className="space-y-4">
                     <div>
                         <label className="block text-sm font-medium text-foreground">Chore Name <span className="text-destructive">*</span></label>
-                        <input type="text" value={choreName} onChange={(e) => setChoreName(e.target.value)} className={inputStyles} />
+                        <Input type="text" value={choreName} onChange={(e) => setChoreName(e.target.value)} className="mt-1" />
                     </div>
                     <div>
                         <label className="block text-sm font-medium text-foreground">Description (Optional)</label>
-                        <textarea value={choreDescription} onChange={(e) => setChoreDescription(e.target.value)} rows={3} className={inputStyles} />
+                        <textarea value={choreDescription} onChange={(e) => setChoreDescription(e.target.value)} rows={3} className={textareaStyles} />
                     </div>
                 </div>
                 <div className="mt-6 flex justify-end space-x-3">

--- a/src/components/ExpenseSplitter.tsx
+++ b/src/components/ExpenseSplitter.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import type { HouseholdMember } from '@/lib/types/types';
 import type { SplitType } from '@/hooks/useExpenseSplits';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
 
 interface ExpenseSplitterProps {
     members: HouseholdMember[];
@@ -40,7 +41,6 @@ export const ExpenseSplitter: React.FC<ExpenseSplitterProps> = ({
         return split ? split.amount : 0;
     };
 
-    const inputSmStyles = "h-9 w-20 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
     const checkboxStyles = "h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary";
 
     return (
@@ -77,12 +77,12 @@ export const ExpenseSplitter: React.FC<ExpenseSplitterProps> = ({
                                 {splitType === 'custom' && includedMembers.has(member.user_id) && (
                                     <div className="flex items-center">
                                         <span className="text-secondary-foreground mr-1">$</span>
-                                        <input type="number" step="0.01" className={inputSmStyles} value={customSplits[member.user_id] || ''} onChange={(e) => setCustomSplits({ ...customSplits, [member.user_id]: parseFloat(e.target.value) || 0 })}/>
+                                        <Input type="number" step="0.01" className="h-9 w-24" value={customSplits[member.user_id] || ''} onChange={(e) => setCustomSplits({ ...customSplits, [member.user_id]: parseFloat(e.target.value) || 0 })}/>
                                     </div>
                                 )}
                                 {splitType === 'percentage' && includedMembers.has(member.user_id) && (
                                      <div className="flex items-center">
-                                        <input type="number" step="0.01" min="0" max="100" className={`${inputSmStyles} w-16`} value={percentageSplits[member.user_id] || ''} onChange={(e) => setPercentageSplits({ ...percentageSplits, [member.user_id]: parseFloat(e.target.value) || 0 })} />
+                                        <Input type="number" step="0.01" min="0" max="100" className="h-9 w-20" value={percentageSplits[member.user_id] || ''} onChange={(e) => setPercentageSplits({ ...percentageSplits, [member.user_id]: parseFloat(e.target.value) || 0 })} />
                                         <span className="text-secondary-foreground ml-1">%</span>
                                     </div>
                                 )}

--- a/src/components/HouseholdChat.tsx
+++ b/src/components/HouseholdChat.tsx
@@ -8,6 +8,7 @@ import { subscriptionManager } from '@/lib/subscriptionManager';
 import type { Message } from '@/lib/types/types';
 import { Button } from '@/components/ui/Button';
 import { toast } from 'react-hot-toast';
+import { Input } from '@/components/ui/Input';
 
 interface HouseholdChatProps {
   householdId: string;
@@ -158,13 +159,13 @@ export const HouseholdChat: React.FC<HouseholdChatProps> = ({ householdId }) => 
 
       <div className="border-t border-border p-4">
         <div className="flex space-x-2">
-          <input
+          <Input
             type="text"
             value={newMessage}
             onChange={(e) => setNewMessage(e.target.value)}
             onKeyPress={handleKeyPress}
             placeholder="Type a message..."
-            className="flex-1 px-4 py-2 border border-input rounded-full focus:outline-none focus:ring-1 focus:ring-ring"
+            className="flex-1 rounded-full"
             disabled={sending}
           />
           <Button

--- a/src/components/HouseholdSettings.tsx
+++ b/src/components/HouseholdSettings.tsx
@@ -17,6 +17,7 @@ import type { Household, HouseholdMember, HouseRule } from '../lib/types/types';
 import { toast } from 'react-hot-toast';
 import { Loader2, Trash2, Shield, LogOut, AlertTriangle, Plus, Edit3 } from 'lucide-react';
 import { Button } from './ui/Button';
+import { Input } from './ui/Input';
 
 interface HouseholdSettingsProps {
   household: Household;
@@ -66,7 +67,7 @@ const AddRuleModal: React.FC<{
     }
   };
 
-  const inputStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm";
+  const textareaStyles = "mt-1 flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
@@ -75,11 +76,11 @@ const AddRuleModal: React.FC<{
         <div className="space-y-4">
           <div>
             <label htmlFor="category" className="block text-sm font-medium text-foreground">Category</label>
-            <input type="text" id="category" value={category} onChange={e => setCategory(e.target.value)} className={inputStyles} placeholder="e.g., Cleanliness, Guests" />
+            <Input type="text" id="category" value={category} onChange={e => setCategory(e.target.value)} className="mt-1" placeholder="e.g., Cleanliness, Guests" />
           </div>
           <div>
             <label htmlFor="content" className="block text-sm font-medium text-foreground">Rule Content</label>
-            <textarea id="content" value={content} onChange={e => setContent(e.target.value)} className={inputStyles} rows={3} placeholder="Describe the rule..."></textarea>
+            <textarea id="content" value={content} onChange={e => setContent(e.target.value)} className={textareaStyles} rows={3} placeholder="Describe the rule..."></textarea>
           </div>
         </div>
         <div className="mt-6 flex justify-end space-x-3">
@@ -120,7 +121,7 @@ const EditRuleModal: React.FC<{
     }
   };
 
-  const inputStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm";
+  const textareaStyles = "mt-1 flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
@@ -129,11 +130,11 @@ const EditRuleModal: React.FC<{
         <div className="space-y-4">
           <div>
             <label htmlFor="edit-category" className="block text-sm font-medium text-foreground">Category</label>
-            <input type="text" id="edit-category" value={category} onChange={e => setCategory(e.target.value)} className={inputStyles} />
+            <Input type="text" id="edit-category" value={category} onChange={e => setCategory(e.target.value)} className="mt-1" />
           </div>
           <div>
             <label htmlFor="edit-content" className="block text-sm font-medium text-foreground">Rule Content</label>
-            <textarea id="edit-content" value={content} onChange={e => setContent(e.target.value)} className={inputStyles} rows={3}></textarea>
+            <textarea id="edit-content" value={content} onChange={e => setContent(e.target.value)} className={textareaStyles} rows={3}></textarea>
           </div>
         </div>
         <div className="mt-6 flex justify-end space-x-3">
@@ -292,7 +293,8 @@ export const HouseholdSettings: React.FC<HouseholdSettingsProps> = ({ household,
 
   const currentUserRole = members.find(m => m.user_id === user?.id)?.role;
   const isAdmin = currentUserRole === 'admin';
-  const inputStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm disabled:opacity-50 disabled:bg-secondary";
+  const selectStyles = "mt-1 flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+
 
   return (
     <>
@@ -307,11 +309,11 @@ export const HouseholdSettings: React.FC<HouseholdSettingsProps> = ({ household,
         >
           <div>
             <label htmlFor="householdName" className="block text-sm font-medium text-foreground">Household Name</label>
-            <input type="text" id="householdName" value={name} onChange={e => setName(e.target.value)} className={inputStyles} disabled={!isAdmin} />
+            <Input type="text" id="householdName" value={name} onChange={e => setName(e.target.value)} className="mt-1" disabled={!isAdmin} />
           </div>
           <div>
             <label htmlFor="memberCount" className="block text-sm font-medium text-foreground">Target Member Count</label>
-            <input type="number" id="memberCount" min="1" value={memberCount} onChange={e => setMemberCount(parseInt(e.target.value, 10))} className={inputStyles} disabled={!isAdmin} />
+            <Input type="number" id="memberCount" min="1" value={memberCount} onChange={e => setMemberCount(parseInt(e.target.value, 10))} className="mt-1" disabled={!isAdmin} />
           </div>
         </SettingsCard>
 
@@ -325,14 +327,14 @@ export const HouseholdSettings: React.FC<HouseholdSettingsProps> = ({ household,
         >
           <div>
               <label htmlFor="choreFramework" className="block text-sm font-medium text-foreground">Chore Framework</label>
-              <select id="choreFramework" value={choreFramework} onChange={e => setChoreFramework(e.target.value as 'Split' | 'One person army')} className={inputStyles} disabled={!isAdmin}>
+              <select id="choreFramework" value={choreFramework} onChange={e => setChoreFramework(e.target.value as 'Split' | 'One person army')} className={selectStyles} disabled={!isAdmin}>
                   <option value="Split">Split - Chores are divided among members each cycle.</option>
                   <option value="One person army">One Person Army - One member does all chores for a cycle.</option>
               </select>
           </div>
           <div>
               <label htmlFor="choreFrequency" className="block text-sm font-medium text-foreground">Chore Frequency</label>
-              <select id="choreFrequency" value={choreFrequency} onChange={e => setChoreFrequency(e.target.value as 'Daily' | 'Weekly' | 'Bi-weekly' | 'Monthly')} className={inputStyles} disabled={!isAdmin}>
+              <select id="choreFrequency" value={choreFrequency} onChange={e => setChoreFrequency(e.target.value as 'Daily' | 'Weekly' | 'Bi-weekly' | 'Monthly')} className={selectStyles} disabled={!isAdmin}>
                   <option value="Daily">Daily</option>
                   <option value="Weekly">Weekly</option>
                   <option value="Bi-weekly">Bi-weekly</option>
@@ -408,12 +410,12 @@ export const HouseholdSettings: React.FC<HouseholdSettingsProps> = ({ household,
                              <label htmlFor="deleteConfirm" className="block text-sm font-medium text-foreground">
                                 Type <span className="font-bold text-destructive">{household.name}</span> to confirm:
                             </label>
-                             <input
+                             <Input
                                 type="text"
                                 id="deleteConfirm"
                                 value={deleteConfirmName}
                                 onChange={(e) => setDeleteConfirmName(e.target.value)}
-                                className={inputStyles}
+                                className="mt-1"
                                 placeholder="Household name"
                             />
                         </div>

--- a/src/components/HouseholdSetupForm.tsx
+++ b/src/components/HouseholdSetupForm.tsx
@@ -8,6 +8,7 @@ import { createHousehold } from '@/lib/api/households';
 import type { CreateHouseholdParams } from '@/lib/types/types';
 import { Button } from '@/components/ui/Button';
 import { Loader2 } from 'lucide-react';
+import { Input } from '@/components/ui/Input';
 
 interface HouseholdSetupFormProps {
   onHouseholdCreated: (householdId: string) => void;
@@ -87,7 +88,7 @@ export const HouseholdSetupForm: React.FC<HouseholdSetupFormProps> = ({ onHouseh
     coreChores.includes(option.value)
   );
 
-  const inputStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm";
+  const selectStyles = "mt-1 flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
 
   return (
     <div className="max-w-lg mx-auto p-6 bg-white rounded-lg shadow-md">
@@ -98,13 +99,13 @@ export const HouseholdSetupForm: React.FC<HouseholdSetupFormProps> = ({ onHouseh
           <label htmlFor="householdName" className="block text-sm font-medium text-foreground">
             Household Name <span className="text-destructive">*</span>
           </label>
-          <input
+          <Input
             type="text"
             id="householdName"
             value={householdName}
             onChange={(e) => setHouseholdName(e.target.value)}
             required
-            className={inputStyles}
+            className="mt-1"
             placeholder="e.g., The Cozy Corner, Apartment 10B"
           />
         </div>
@@ -113,14 +114,14 @@ export const HouseholdSetupForm: React.FC<HouseholdSetupFormProps> = ({ onHouseh
           <label htmlFor="memberCount" className="block text-sm font-medium text-foreground">
             Target Number of Members <span className="text-destructive">*</span>
           </label>
-          <input
+          <Input
             type="number"
             id="memberCount"
             value={memberCount}
             onChange={(e) => setMemberCount(parseInt(e.target.value, 10))}
             min="1"
             required
-            className={inputStyles}
+            className="mt-1"
           />
         </div>
         
@@ -149,7 +150,7 @@ export const HouseholdSetupForm: React.FC<HouseholdSetupFormProps> = ({ onHouseh
             id="choreFrequency"
             value={choreFrequency}
             onChange={(e) => setChoreFrequency(e.target.value)}
-            className={inputStyles}
+            className={selectStyles}
           >
             <option value="Weekly">Weekly</option>
             <option value="Bi-weekly">Bi-weekly</option>
@@ -167,7 +168,7 @@ export const HouseholdSetupForm: React.FC<HouseholdSetupFormProps> = ({ onHouseh
             value={choreFramework}
             onChange={(e) => setChoreFramework(e.target.value)}
             required
-            className={inputStyles}
+            className={selectStyles}
           >
             <option value="Split">Split</option>
             <option value="One person army">One person army</option>

--- a/src/components/RoomiesApp.tsx
+++ b/src/components/RoomiesApp.tsx
@@ -25,6 +25,7 @@ import { AddRecurringExpenseModal } from './AddRecurringExpenseModal';
 import { SettleUpModal } from './SettleUpModal';
 import { ManageJoinCodeModal } from './ManageJoinCodeModal';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
 
 const Layout: React.FC<{ children: React.ReactNode; title?: string; showBack?: boolean; onBack?: () => void }> = ({
   children,
@@ -129,8 +130,6 @@ const AuthForm: React.FC<{isRegisteringInitially: boolean}> = ({isRegisteringIni
     if (e.key === 'Enter' && !isLoading) handleSubmit();
   };
 
-  const inputStyles = `relative block w-full appearance-none px-3 py-2 border border-input text-foreground placeholder-secondary-foreground/50 focus:z-10 focus:border-ring focus:outline-none focus:ring-ring sm:text-sm`;
-
   return (
     <div className="min-h-screen flex items-center justify-center bg-background py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
@@ -146,14 +145,14 @@ const AuthForm: React.FC<{isRegisteringInitially: boolean}> = ({isRegisteringIni
           <div className="rounded-md shadow-sm -space-y-px">
             {isRegistering && (
               <div>
-                <input type="text" required className={`${inputStyles} rounded-t-md`} placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} onKeyPress={handleKeyPress}/>
+                <Input type="text" required className="rounded-b-none" placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} onKeyPress={handleKeyPress}/>
               </div>
             )}
             <div>
-              <input type="email" required className={`${inputStyles} ${isRegistering ? '' : 'rounded-t-md'}`} placeholder="Email address" value={email} onChange={(e) => setEmail(e.target.value)} onKeyPress={handleKeyPress} />
+              <Input type="email" required className={isRegistering ? '' : 'rounded-t-md'} placeholder="Email address" value={email} onChange={(e) => setEmail(e.target.value)} onKeyPress={handleKeyPress} />
             </div>
             <div>
-              <input type="password" required className={`${inputStyles} rounded-b-md`} placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} onKeyPress={handleKeyPress} />
+              <Input type="password" required className="rounded-t-none" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} onKeyPress={handleKeyPress} />
             </div>
           </div>
 
@@ -203,8 +202,6 @@ const JoinHouseholdWithCode: React.FC<{ onJoined: (household: Household) => void
     }
   };
 
-  const inputStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm uppercase tracking-widest text-center";
-
   return (
     <div className="max-w-md mx-auto bg-background p-8 rounded-lg shadow-md">
       <h2 className="text-2xl font-bold text-foreground mb-6 text-center">Enter Join Code</h2>
@@ -212,7 +209,7 @@ const JoinHouseholdWithCode: React.FC<{ onJoined: (household: Household) => void
       <div className="space-y-4">
         <div>
           <label htmlFor="joinCode" className="block text-sm font-medium text-foreground">4-Character Code</label>
-          <input type="text" id="joinCode" value={joinCode} onChange={(e) => setJoinCode(e.target.value.toUpperCase().trim())} maxLength={4} className={inputStyles} placeholder="XYZ1" autoCapitalize="characters" autoComplete="off" spellCheck="false" />
+          <Input type="text" id="joinCode" value={joinCode} onChange={(e) => setJoinCode(e.target.value.toUpperCase().trim())} maxLength={4} className="mt-1 uppercase tracking-widest text-center" placeholder="XYZ1" autoCapitalize="characters" autoComplete="off" spellCheck="false" />
         </div>
         {error && <p className="text-destructive text-sm text-center">{error}</p>}
         <Button onClick={handleSubmit} disabled={isLoading || joinCode.length !== 4} className="w-full">

--- a/src/components/SettleUpModal.tsx
+++ b/src/components/SettleUpModal.tsx
@@ -8,6 +8,7 @@ import { toast } from 'react-hot-toast';
 import type { HouseholdMember, Profile } from '@/lib/types/types';
 import { useAuth } from './AuthProvider';
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
 
 interface SettleUpModalProps {
   householdId: string;
@@ -76,7 +77,7 @@ export const SettleUpModal: React.FC<SettleUpModalProps> = ({ householdId, membe
     const myDebts = settlementSuggestions.filter(s => s.from === user?.id);
     const owedToMe = settlementSuggestions.filter(s => s.to === user?.id);
     
-    const inputStyles = "mt-1 block w-full px-3 py-2 border border-input rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-ring sm:text-sm";
+    const selectStyles = "mt-1 flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
 
     return (
       <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 overflow-y-auto">
@@ -131,7 +132,7 @@ export const SettleUpModal: React.FC<SettleUpModalProps> = ({ householdId, membe
           <div className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-foreground">Pay to</label>
-              <select className={inputStyles} value={payeeId} onChange={(e) => setPayeeId(e.target.value)}>
+              <select className={selectStyles} value={payeeId} onChange={(e) => setPayeeId(e.target.value)}>
                 <option value="">Select recipient</option>
                 {members.filter(member => member.user_id !== user?.id).map(member => (
                   <option key={member.user_id} value={member.user_id}>{member.profiles?.name}</option>
@@ -140,11 +141,11 @@ export const SettleUpModal: React.FC<SettleUpModalProps> = ({ householdId, membe
             </div>
             <div>
               <label className="block text-sm font-medium text-foreground">Amount</label>
-              <input type="number" step="0.01" className={inputStyles} value={customAmount} onChange={(e) => setCustomAmount(e.target.value)} placeholder="0.00"/>
+              <Input type="number" step="0.01" className="mt-1" value={customAmount} onChange={(e) => setCustomAmount(e.target.value)} placeholder="0.00"/>
             </div>
             <div>
               <label className="block text-sm font-medium text-foreground">Description (optional)</label>
-              <input type="text" className={inputStyles} value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Payment for..."/>
+              <Input type="text" className="mt-1" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Payment for..."/>
             </div>
           </div>
 

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,73 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }

--- a/src/components/ui/Collapsible.tsx
+++ b/src/components/ui/Collapsible.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+const Collapsible = CollapsiblePrimitive.Root
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,26 @@
+// src/components/ui/input.tsx
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
This commit adds the shadcn/ui `Input` component to standardize form elements across the application, creating a more consistent and modern user interface.

- Added `clsx` and `tailwind-merge` dependencies to support the `cn` utility function.
- Created the reusable `Input` component in `src/components/ui/`.
- Refactored all existing `<input>` fields in modals and forms to use the new `Input` component.
- Styled related `<select>` and `<textarea>` elements to visually match the new input fields for a cohesive look.

Affected components include:
- AddExpenseModal
- AddRecurringExpenseModal
- AddTaskModal
- ChoreDashboard (modals)
- ExpenseSplitter
- HouseholdChat
- HouseholdSettings (and modals)
- HouseholdSetupForm
- RoomiesApp (AuthForm, JoinHouseholdWithCode)
- SettleUpModal